### PR TITLE
Update go.mod

### DIFF
--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/patsec/ot-sim
 
-go 1.22
+go 1.22.0
 
 require (
 	actshad.dev/mbserver v0.3.1


### PR DESCRIPTION
go v1.22 does not have a toolchain causes errrors building ot-sim.qc2. 1.22.0 has a toolchain and building the qc2 succeeds