### PR TITLE
chore(node-red): bump zmq dep

### DIFF
--- a/src/js/node-red/package.json
+++ b/src/js/node-red/package.json
@@ -2,7 +2,7 @@
   "name": "node-red-contrib-ot-sim",
   "version": "0.0.1",
   "dependencies": {
-    "zeromq": "^5.3.1"
+    "zeromq": "^6.4.0"
   },
   "node-red": {
     "nodes": {


### PR DESCRIPTION
Builds seem to be failing on zmq version `^5.3.1`. I have not tested if the node-red functionality still works as expected, but this at least builds